### PR TITLE
Coerce `check_for_rescue` to logical

### DIFF
--- a/CSI-GEP/GEP_analysis.R
+++ b/CSI-GEP/GEP_analysis.R
@@ -56,7 +56,7 @@ output.dir <- args[3]
 ranks = scan(text=args[4], sep = ",")
 print(ranks)
 
-check_for_rescue = as.numeric(args[5])
+check_for_rescue = as.logical(as.numeric(args[5]))
 
 jaccard.val <- c(seq(10,100,10))
     


### PR DESCRIPTION
Fixes invalid argument type error: `if(!(check_for_rescue)` (#1)